### PR TITLE
Runtime Editing of INPUT_SHAPING parameters

### DIFF
--- a/Marlin/src/gcode/feature/input_shaping/M593.cpp
+++ b/Marlin/src/gcode/feature/input_shaping/M593.cpp
@@ -1,0 +1,84 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../../inc/MarlinConfig.h"
+
+#if ENABLED(INPUT_SHAPING)
+
+#include "../../gcode.h"
+#include "../../../module/stepper.h"
+
+/**
+ * M593: Get or Set Input Shaping Parameters
+ *  D<factor>    Set the zeta/damping factor. If axes (X, Y, etc.) are not specified, set for all axes.
+ *  F<frequency> Set the frequency. If axes (X, Y, etc.) are not specified, set for all axes.
+ *  T[map]       Input Shaping type, 0:ZV, 1:EI, 2:2H EI (not implemented yet)
+ *  X<1>         Set the given parameters only for the X axis.
+ *  Y<1>         Set the given parameters only for the Y axis.
+ */
+void GcodeSuite::M593() {
+  const bool seen_X = parser.seen('X'),
+             for_X = seen_X ? parser.value_bool() : false;
+  const bool seen_Y = parser.seen('Y'),
+             for_Y = seen_Y ? parser.value_bool() : false;
+
+  if (parser.seen('D')) {
+    const float zeta = parser.value_float();
+    if (WITHIN(zeta, 0, 1)) {
+      if (for_X || (!for_X && !for_Y)) stepper.set_shaping_damping_ratio(X_AXIS, zeta);
+      if (for_Y || (!for_X && !for_Y)) stepper.set_shaping_damping_ratio(Y_AXIS, zeta);
+    } else {
+      SERIAL_ECHO_START();
+      SERIAL_ECHOLNPGM("Zeta (D) value out of range (0-1)");
+    }
+  }
+
+  if (parser.seen('F')) {
+    const float freq = parser.value_float();
+    if (freq <= 0) {
+      SERIAL_ECHO_START();
+      SERIAL_ECHOLNPGM("Frequency (F) must be greater than 0");
+    } else {
+      if (for_X || (!for_X && !for_Y)) stepper.set_shaping_frequency(X_AXIS, freq);
+      if (for_Y || (!for_X && !for_Y)) stepper.set_shaping_frequency(Y_AXIS, freq);
+    }
+  }
+
+  if (!parser.seen_any()) {
+    SERIAL_ECHO_START();
+    SERIAL_ECHOLNPGM("Input Shaping:");
+    #if HAS_SHAPING_X
+      SERIAL_ECHO_START();
+      SERIAL_ECHOLNPGM("  X axis: M593 X F", stepper.get_shaping_frequency(X_AXIS),
+        " D", stepper.get_shaping_damping_ratio(X_AXIS));
+    #endif
+    #if HAS_SHAPING_Y
+      SERIAL_ECHO_START();
+      SERIAL_ECHOLNPGM("  Y axis: M593 Y F", stepper.get_shaping_frequency(Y_AXIS),
+        " D", stepper.get_shaping_damping_ratio(Y_AXIS));
+    #endif
+  }
+
+}
+
+
+#endif // INPUT_SHAPING

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -927,6 +927,10 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
         case 575: M575(); break;                                  // M575: Set serial baudrate
       #endif
 
+      #if ENABLED(INPUT_SHAPING)
+        case 593: M593(); break;                                  // M593: Set Input Shaping parameters
+      #endif
+
       #if ENABLED(ADVANCED_PAUSE_FEATURE)
         case 600: M600(); break;                                  // M600: Pause for Filament Change
         case 603: M603(); break;                                  // M603: Configure Filament Change

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -259,6 +259,7 @@
  * M554 - Get or set IP gateway. (Requires enabled Ethernet port)
  * M569 - Enable stealthChop on an axis. (Requires at least one _DRIVER_TYPE to be TMC2130/2160/2208/2209/5130/5160)
  * M575 - Change the serial baud rate. (Requires BAUD_RATE_GCODE)
+ * M593 - Get or set input shaping parameters. (Requires INPUT_SHAPING)
  * M600 - Pause for filament change: "M600 X<pos> Y<pos> Z<raise> E<first_retract> L<later_retract>". (Requires ADVANCED_PAUSE_FEATURE)
  * M603 - Configure filament change: "M603 T<tool> U<unload_length> L<load_length>". (Requires ADVANCED_PAUSE_FEATURE)
  * M605 - Set Dual X-Carriage movement mode: "M605 S<mode> [X<x_offset>] [R<temp_offset>]". (Requires DUAL_X_CARRIAGE)
@@ -1078,6 +1079,10 @@ private:
 
   #if ENABLED(BAUD_RATE_GCODE)
     static void M575();
+  #endif
+
+  #if ENABLED(INPUT_SHAPING)
+    static void M593();
   #endif
 
   #if ENABLED(ADVANCED_PAUSE_FEATURE)

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -466,18 +466,22 @@ class Stepper {
 
     #if ENABLED(INPUT_SHAPING)
       #if HAS_SHAPING_X
+        static float                              shaping_zeta_x;
         static uint8_t                            shaping_factor_x;
         static DelayQueue<SHAPING_BUFFER_X>       shaping_queue_x;
         static ParamDelayQueue<SHAPING_SEGMENTS>  shaping_dividend_queue_x;
         static int32_t                            shaping_dividend_x;
-        static constexpr shaping_time_t           shaping_delay_x = uint32_t(STEPPER_TIMER_RATE) / (SHAPING_FREQ_X) / 2;
+        static float                              shaping_frequency_x;
+        static shaping_time_t                     shaping_delay_x;
       #endif
       #if HAS_SHAPING_Y
+        static float                              shaping_zeta_y;
         static uint8_t                            shaping_factor_y;
         static DelayQueue<SHAPING_BUFFER_Y>       shaping_queue_y;
         static ParamDelayQueue<SHAPING_SEGMENTS>  shaping_dividend_queue_y;
         static int32_t                            shaping_dividend_y;
-        static constexpr shaping_time_t           shaping_delay_y = uint32_t(STEPPER_TIMER_RATE) / (SHAPING_FREQ_Y) / 2;
+        static float                              shaping_frequency_y;
+        static shaping_time_t                     shaping_delay_y;
       #endif
     #endif
 
@@ -702,6 +706,9 @@ class Stepper {
 
     #if ENABLED(INPUT_SHAPING)
       static void set_shaping_damping_ratio(const AxisEnum axis, const float zeta);
+      static float get_shaping_damping_ratio(const AxisEnum axis);
+      static void set_shaping_frequency(const AxisEnum axis, const float freq);
+      static float get_shaping_frequency(const AxisEnum axis);
     #endif
 
   private:

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -187,6 +187,7 @@ HAS_DUPLICATION_MODE                   = src_filter=+<src/gcode/control/M605.cpp
 LIN_ADVANCE                            = src_filter=+<src/gcode/feature/advance>
 PHOTO_GCODE                            = src_filter=+<src/gcode/feature/camera>
 CONTROLLER_FAN_EDITABLE                = src_filter=+<src/gcode/feature/controllerfan>
+INPUT_SHAPING                          = src_filter=+<src/gcode/feature/input_shaping>
 GCODE_MACROS                           = src_filter=+<src/gcode/feature/macro>
 GRADIENT_MIX                           = src_filter=+<src/gcode/feature/mixing/M166.cpp>
 HAS_SAVED_POSITIONS                    = src_filter=+<src/gcode/feature/pause/G60.cpp> +<src/gcode/feature/pause/G61.cpp>

--- a/platformio.ini
+++ b/platformio.ini
@@ -192,6 +192,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared> -<src/t
   -<src/gcode/feature/advance>
   -<src/gcode/feature/camera>
   -<src/gcode/feature/i2c>
+  -<src/gcode/feature/input_shaping>
   -<src/gcode/feature/L6470>
   -<src/gcode/feature/leds/M150.cpp>
   -<src/gcode/feature/leds/M7219.cpp>


### PR DESCRIPTION
This is a starting point to get the frequency and zeta as editable at runtime.

This is implemented as `M593`, which is the most appropriate existing GCODE. The RepRap wiki will need to be updated once the usage is finalized.

Current usage:
```C++
/**
 * M593: Get or Set Input Shaping Parameters
 *  D<factor>    Set the zeta/damping factor. If axes (X, Y, etc.) are not specified, set for all axes.
 *  F<frequency> Set the frequency. If axes (X, Y, etc.) are not specified, set for all axes.
 *  T[map]       Input Shaping type, 0:ZV, 1:EI, 2:2H EI (not implemented yet)
 *  X<1>         Set the given parameters only for the X axis.
 *  Y<1>         Set the given parameters only for the Y axis.
 */
```

`T` is completely unimplemented but I left the comment there as a reminder of how it can work.

Example usage:
```
Send: M593
Recv: echo:Input Shaping:
Recv: echo:  X axis: M593 X F40.00 D0.30
Recv: echo:  Y axis: M593 Y F40.00 D0.30
Recv: ok
Send: M593 X F32.61 D0
Recv: ok
Send: M593 Y F40.32 D0
Recv: ok
Send: M593
Recv: echo:Input Shaping:
Recv: echo:  X axis: M593 X F32.61 D0.00
Recv: echo:  Y axis: M593 Y F40.32 D0.00
Recv: ok
```

Notes:
 - `HAS_SHAPING_X` and `HAS_SHAPING_Y` will still be based upon the compile time logic, which means disabling an axis at runtime isn't possible. I think it'd be intuitive to set Frequency to 0 to disable an axis, but I'm not sure how to properly implement that (and I didn't want to touch the actual input shaping stuff too much 😃)